### PR TITLE
There was a missing dependency called 'copyfiles'

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-plugin-transform-runtime": "^6.3.13",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
+    "copyfiles": "^0.2.1",
     "css-loader": "^0.23.1",
     "eslint": "^1.10.3",
     "eslint-config-hapi": "^8.0.0",


### PR DESCRIPTION
Probably globally installed at your end.
